### PR TITLE
[FFM-2680]: Adding test case for empty target attribute

### DIFF
--- a/tests/test_empty_or_missing_target_attributes.json
+++ b/tests/test_empty_or_missing_target_attributes.json
@@ -1,0 +1,61 @@
+{
+  "flag": {
+    "defaultServe": { "distribution": null, "variation": "true" },
+    "environment": "demoenv",
+    "feature": "AlfaTest",
+    "kind": "boolean",
+    "offVariation": "false",
+    "prerequisites": [],
+    "project": "FeatureFlagsDemo",
+    "rules": [
+      {
+        "ruleId": "",
+        "priority": 999,
+        "clauses": [
+          {
+            "id": "",
+            "attribute": "companyName",
+            "op": "equal",
+            "values": ["harness"]
+          }
+        ],
+        "serve": {
+          "distribution": null,
+          "variation": "false"
+        }
+      }
+    ],
+    "state": "on",
+    "variationToTargetMap": null,
+    "variations": [
+      {
+        "description": null,
+        "identifier": "true",
+        "name": "Enable Page",
+        "value": "true"
+      },
+      {
+        "description": null,
+        "identifier": "false",
+        "name": "Disable Page",
+        "value": "false"
+      }
+    ]
+  },
+  "targets": [
+    {
+      "identifier": "harness",
+      "name": "Harness"
+    },
+    {
+      "identifier": "john",
+      "attributes": {
+        "email": "john@beatles.com"
+      }
+    }
+  ],
+  "expected": {
+    "_no_target": true,
+    "john": true 
+  }
+}


### PR DESCRIPTION
### What
When a target has an empty or missing attribute that is used in
a custom rule, then the Java SDK throws a NullPointerException

### Why
Adding this test case to replicate.

