### PR TITLE
Fix test case for prereqs

### DIFF
--- a/tests/prereq.json
+++ b/tests/prereq.json
@@ -2,11 +2,11 @@
   "apiVersion": "1.0",
   "flags": [
     {
-      "defaultServe": { "distribution": null, "variation": "true" },
+      "defaultServe": { "distribution": null, "variation": "enable" },
       "environment": "dev",
       "feature": "bool-flag-prereq",
       "kind": "boolean",
-      "offVariation": "false",
+      "offVariation": "disable",
       "prerequisites": [],
       "project": "default",
       "rules": [
@@ -23,7 +23,7 @@
           ],
           "serve": {
             "distribution": null,
-            "variation": "false"
+            "variation": "disable"
           }
         }
       ],
@@ -32,13 +32,13 @@
       "variations": [
         {
           "description": null,
-          "identifier": "true",
+          "identifier": "enable",
           "name": "Enable Page",
           "value": "true"
         },
         {
           "description": null,
-          "identifier": "false",
+          "identifier": "disable",
           "name": "Disable Page",
           "value": "false"
         }
@@ -53,7 +53,7 @@
       "prerequisites": [
         {
           "feature": "bool-flag-prereq",
-          "variations": ["true", "false"]
+          "variations": ["enable", "disable"]
         }
       ],
       "project": "default",


### PR DESCRIPTION
WHAT

Evaluation checks for Pre-Req flags were incorrectly implemented in some Server SDKs, as they were checking for `value` instead of `identifier` this was uncaught previously because the test cases used boolean flags which had the same string for `identifier` and `value`.

FIX
The API supports creating a boolean flag where the identifier is not `true` or `false`, but the UI locks those `identifier` values, so this test case is updated with that in mind. If down the road we enforce or implement the UI behavior on the backend, this test case may need to change.