### PR TITLE
FFM-5306 - Update ff-test-cases for prereq id/value mismatch

### DIFF
--- a/tests/prereq.json
+++ b/tests/prereq.json
@@ -91,6 +91,67 @@
           "value": "false"
         }
       ]
+    },
+    {
+      "defaultServe": {
+        "variation": "On"
+      },
+      "environment": "myenv",
+      "feature": "feature-flag-with-mixed-id-and-values",
+      "kind": "string",
+      "offVariation": "Off",
+      "prerequisites": [],
+      "project": "ffsynctest",
+      "rules": [],
+      "state": "on",
+      "variationToTargetMap": null,
+      "variations": [
+        {
+          "identifier": "On",
+          "name": "On",
+          "value": "true"
+        },
+        {
+          "identifier": "Off",
+          "name": "Off",
+          "value": "false"
+        }
+      ]
+    },
+
+    {
+      "defaultServe": {
+        "variation": "name1"
+      },
+      "environment": "myenv",
+      "feature": "string-flag-with-dependency",
+      "kind": "string",
+      "offVariation": "name2",
+      "prerequisites": [
+        {
+          "ParentFeature": "e9ecd67a-d91f-49fd-af96-a2b085b8109a",
+          "feature": "feature-flag-with-mixed-id-and-values",
+          "variations": [
+            "On"
+          ]
+        }
+      ],
+      "project": "ffsynctest",
+      "rules": [],
+      "state": "on",
+      "variationToTargetMap": null,
+      "variations": [
+        {
+          "identifier": "name1",
+          "name": "name1",
+          "value": "value1"
+        },
+        {
+          "identifier": "name2",
+          "name": "name2",
+          "value": "value2"
+        }
+      ]
     }
   ],
   "targets": [
@@ -101,6 +162,7 @@
   ],
   "tests": [
     { "flag": "bool-flag", "expected": true },
-    { "flag": "bool-flag", "target": "harness", "expected": false }
+    { "flag": "bool-flag", "target": "harness", "expected": false },
+    { "flag": "string-flag-with-dependency", "expected": "value1" }
   ]
 }


### PR DESCRIPTION
What
Update test cases to include a test for prereq using different ids and values. string-flag-with-dependency feature has a dependency on feature-flag-with-mixed-id-and-values which will trigger the bug.

Why
We're incorrectly matching values when we should be using identifiers. This can cause features not to trigger.

Testing
Tested with Java SDK integration tests