### PR TITLE
[FFM-5387]: Add ff-test-grid converted test cases

### DIFF
--- a/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_False_Should_Return_False.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_False_Should_Return_False.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_False_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_False_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_True_Should_Return_True.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_True_Should_Return_True.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_True_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Bool_State_Disabled_On_False_Off_True_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_False_Should_Return_False.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_False_Should_Return_False.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_False_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_False_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_True_Should_Return_True.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_True_Should_Return_True.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_True_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Bool_State_Disabled_On_True_Off_True_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_JSON_State_Disabled_On_complexJSON_Off_emptyJSON_Should_Return_validJSON.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_JSON_State_Disabled_On_complexJSON_Off_emptyJSON_Should_Return_validJSON.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_JSON_State_Disabled_On_complexJSON_Off_emptyJSON_Should_Return_validJSON",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_JSON_State_Disabled_On_complexJSON_Off_emptyJSON_Should_Return_validJSON",
+			"expected": "{\"number\": \"£5\"}"
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_JSON_State_Disabled_On_validJSON_Off_emptyJSON_Should_Return_emptyJSON.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_JSON_State_Disabled_On_validJSON_Off_emptyJSON_Should_Return_emptyJSON.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "validJSON"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_JSON_State_Disabled_On_validJSON_Off_emptyJSON_Should_Return_emptyJSON",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_JSON_State_Disabled_On_validJSON_Off_emptyJSON_Should_Return_emptyJSON",
+			"expected": "{}"
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_Number_State_Disabled_On_011_Off_2_Should_Return_2.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Number_State_Disabled_On_011_Off_2_Should_Return_2.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "0.11"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Number_State_Disabled_On_011_Off_2_Should_Return_2",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Number_State_Disabled_On_011_Off_2_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_Number_State_Disabled_On_324523_Off_011_Should_Return_011.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_Number_State_Disabled_On_324523_Off_011_Should_Return_011.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "324523"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_Number_State_Disabled_On_324523_Off_011_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_Number_State_Disabled_On_324523_Off_011_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_String_State_Disabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet53.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_String_State_Disabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet53.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_String_State_Disabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet53",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_String_State_Disabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet53",
+			"expected": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+		}
+	]
+}

--- a/tests/DefaultOffRules/DefaultOffRules_Type_String_State_Disabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet19.json
+++ b/tests/DefaultOffRules/DefaultOffRules_Type_String_State_Disabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet19.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet53"
+			},
+			"environment": "",
+			"feature": "DefaultOffRules_Type_String_State_Disabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet19",
+			"kind": "string",
+			"offVariation": "sonnet19",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOffRules_Type_String_State_Disabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet19",
+			"expected": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_False_Should_Return_False.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_False_Should_Return_False.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_False_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_False_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_True_Should_Return_True.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_True_Should_Return_True.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_True_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Bool_State_Enabled_On_False_Off_True_Should_Return_True",
+			"expected": false
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_False_Should_Return_False.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_False_Should_Return_False.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_False_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_False_Should_Return_False",
+			"expected": true
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_True_Should_Return_True.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_True_Should_Return_True.json
@@ -1,0 +1,615 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_True_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Bool_State_Enabled_On_True_Off_True_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_JSON_State_Enabled_On_complexJSON_Off_emptyJSON_Should_Return_complexJSON.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_JSON_State_Enabled_On_complexJSON_Off_emptyJSON_Should_Return_complexJSON.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_JSON_State_Enabled_On_complexJSON_Off_emptyJSON_Should_Return_complexJSON",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_JSON_State_Enabled_On_complexJSON_Off_emptyJSON_Should_Return_complexJSON",
+			"expected": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_JSON_State_Enabled_On_validJSON_Off_emptyJSON_Should_Return_validJSON.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_JSON_State_Enabled_On_validJSON_Off_emptyJSON_Should_Return_validJSON.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "validJSON"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_JSON_State_Enabled_On_validJSON_Off_emptyJSON_Should_Return_validJSON",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_JSON_State_Enabled_On_validJSON_Off_emptyJSON_Should_Return_validJSON",
+			"expected": "{\"number\": \"£5\"}"
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Number_State_Enabled_On_011_Off_2_Should_Return_011.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Number_State_Enabled_On_011_Off_2_Should_Return_011.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "0.11"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Number_State_Enabled_On_011_Off_2_Should_Return_011",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Number_State_Enabled_On_011_Off_2_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_Number_State_Enabled_On_324523_Off_011_Should_Return_324523.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_Number_State_Enabled_On_324523_Off_011_Should_Return_324523.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "324523"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_Number_State_Enabled_On_324523_Off_011_Should_Return_324523",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_Number_State_Enabled_On_324523_Off_011_Should_Return_324523",
+			"expected": 324523
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_String_State_Enabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet19.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_String_State_Enabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet19.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_String_State_Enabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet19",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_String_State_Enabled_On_sonnet19_Off_sonnet53_Should_Return_sonnet19",
+			"expected": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+		}
+	]
+}

--- a/tests/DefaultOnRules/DefaultOnRules_Type_String_State_Enabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet53.json
+++ b/tests/DefaultOnRules/DefaultOnRules_Type_String_State_Enabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet53.json
@@ -1,0 +1,621 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet53"
+			},
+			"environment": "",
+			"feature": "DefaultOnRules_Type_String_State_Enabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet53",
+			"kind": "string",
+			"offVariation": "sonnet19",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "DefaultOnRules_Type_String_State_Enabled_On_sonnet53_Off_sonnet19_Should_Return_sonnet53",
+			"expected": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_false_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_false_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_false_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"EqualsThree"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "09b2aff3-f9fb-4b7c-87de-7b6d785d9147",
+					"serve": {
+						"variation": "false"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_false_for_Target_three",
+			"target": "three",
+			"expected": false
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_true_for_Target_one.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_true_for_Target_one.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_true_for_Target_one",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"EqualsThree"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "ff742e35-8f9e-4ca2-9a22-6bfe51c14f5d",
+					"serve": {
+						"variation": "false"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_EqualsThree_Should_Return_true_for_Target_one",
+			"target": "one",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_GroupWithMultipleOrRules_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_GroupWithMultipleOrRules_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_GroupWithMultipleOrRules_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"GroupWithMultipleOrRules"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "e8c6a3ec-d196-4c2a-a840-d87144ee0c03",
+					"serve": {
+						"variation": "true"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_GroupWithMultipleOrRules_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_InOneTwoThree_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_InOneTwoThree_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_InOneTwoThree_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"InOneTwoThree"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "e69e9783-6664-4769-bfd1-cfa57c4d4397",
+					"serve": {
+						"variation": "true"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_InOneTwoThree_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_IncludeAndExcludeGroup_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_IncludeAndExcludeGroup_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_IncludeAndExcludeGroup_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"IncludeAndExcludeGroup"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "0baf2060-7472-420c-854b-3fd8b61773cd",
+					"serve": {
+						"variation": "true"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_IncludeAndExcludeGroup_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_IncludedOnly_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_IncludedOnly_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_IncludedOnly_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"IncludedOnly"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "203b83a9-f8ba-4ee5-8101-58145e5bf91a",
+					"serve": {
+						"variation": "true"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_IncludedOnly_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithTExcludesThree_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithTExcludesThree_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_StartsWithTExcludesThree_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"StartsWithTExcludesThree"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "b7713aaf-31e5-4771-b039-43e1b072eb19",
+					"serve": {
+						"variation": "false"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_StartsWithTExcludesThree_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_false_for_Target_one.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_false_for_Target_one.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_false_for_Target_one",
+			"kind": "boolean",
+			"offVariation": "true",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"StartsWithT"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "16faada6-9bbf-4de0-868b-e3a8e67ddbe6",
+					"serve": {
+						"variation": "false"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_false_for_Target_one",
+			"target": "one",
+			"expected": true
+		}
+	]
+}

--- a/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_true_for_Target_three.json
+++ b/tests/GroupRules/GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_true_for_Target_three.json
@@ -1,0 +1,634 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": [
+				{
+					"clauses": [
+						{
+							"attribute": "",
+							"negate": false,
+							"op": "segmentMatch",
+							"values": [
+								"StartsWithT"
+							]
+						}
+					],
+					"priority": 0,
+					"ruleId": "9a7d1ae5-f8fc-434a-ac15-d0a38f9756ad",
+					"serve": {
+						"variation": "true"
+					}
+				}
+			],
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "GroupRules_Type_Bool_State_Enabled_StartsWithT_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False.json
+++ b/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+					"variations": [
+						"true"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True.json
+++ b/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+					"variations": [
+						"false"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolBool_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False.json
+++ b/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+					"variations": [
+						"false"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True.json
+++ b/tests/Prerequisites/Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+					"variations": [
+						"true"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolBool_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False.json
+++ b/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+					"variations": [
+						"2"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True.json
+++ b/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+					"variations": [
+						"0.11"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolInt_State_Enabled_On_True_Off_False_Prerequisites_AlwaysOff_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False.json
+++ b/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+					"variations": [
+						"0.11"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_False",
+			"expected": false
+		}
+	]
+}

--- a/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True.json
+++ b/tests/Prerequisites/Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True.json
@@ -1,0 +1,622 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+					"variations": [
+						"2"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_BoolInt_State_Enabled_On_True_Off_True_Prerequisites_AlwaysOn_Should_Return_True",
+			"expected": true
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+					"variations": [
+						"true"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+					"variations": [
+						"false"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+					"variations": [
+						"false"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+					"variations": [
+						"true"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntBool_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+					"variations": [
+						"2"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+					"variations": [
+						"0.11"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+					"variations": [
+						"0.11"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+					"variations": [
+						"2"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntInt_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+					"variations": [
+						"complexJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+					"variations": [
+						"validJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+					"variations": [
+						"validJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+					"variations": [
+						"complexJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntJson_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet19"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet53"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOff_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
+++ b/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet53"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_011",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
+++ b/tests/Prerequisites/Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet19"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_IntString_State_Enabled_On_2_Off_011_Prerequisites_AlwaysOn_Should_Return_2",
+			"expected": 2
+		}
+	]
+}

--- a/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Com.json
+++ b/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Com.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Com",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+					"variations": [
+						"validJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				},
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Com",
+			"expected": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+		}
+	]
+}

--- a/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Val.json
+++ b/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Val.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Val",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+					"variations": [
+						"complexJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOff_Should_Return_Val",
+			"expected": "{\"number\": \"£5\"}"
+		}
+	]
+}

--- a/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Com.json
+++ b/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Com.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Com",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+					"variations": [
+						"complexJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				},
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Com",
+			"expected": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+		}
+	]
+}

--- a/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Val.json
+++ b/tests/Prerequisites/Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Val.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Val",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+					"variations": [
+						"validJSON"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				},
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_JsonJson_State_Enabled_On_com_Off_val_Prerequisites_AlwaysOn_Should_Return_Val",
+			"expected": "{\"number\": \"£5\"}"
+		}
+	]
+}

--- a/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_off.json
+++ b/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_off.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_off",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet19"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_off",
+			"expected": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+		}
+	]
+}

--- a/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_on.json
+++ b/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_on.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_on",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet53"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOff_Should_Return_on",
+			"expected": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+		}
+	]
+}

--- a/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_Off.json
+++ b/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_Off.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_Off",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet53"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_Off",
+			"expected": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+		}
+	]
+}

--- a/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_On.json
+++ b/tests/Prerequisites/Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_On.json
@@ -1,0 +1,628 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_On",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": [
+				{
+					"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+					"variations": [
+						"sonnet19"
+					]
+				}
+			],
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "Type_StrStr_State_Enabled_On_s19_Off_s53_Prerequisites_AlwaysOn_Should_Return_On",
+			"expected": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Bool_State_Disabled_Should_Return_Default_Off_Value.json
+++ b/tests/TargetRules/TargetRules_Type_Bool_State_Disabled_Should_Return_Default_Off_Value.json
@@ -1,0 +1,638 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Bool_State_Disabled_Should_Return_Default_Off_Value",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "true"
+				}
+			],
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Bool_State_Disabled_Should_Return_Default_Off_Value",
+			"target": "three",
+			"expected": false
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_four.json
+++ b/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_four.json
@@ -1,0 +1,638 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_four",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "true"
+				}
+			],
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_four",
+			"target": "four",
+			"expected": false
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_six.json
+++ b/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_six.json
@@ -1,0 +1,659 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_six",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "true"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "false"
+				}
+			],
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Bool_State_Enabled_Should_Return_false_for_Target_six",
+			"target": "six",
+			"expected": false
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_true_for_Target_three.json
+++ b/tests/TargetRules/TargetRules_Type_Bool_State_Enabled_Should_Return_true_for_Target_three.json
@@ -1,0 +1,638 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "false"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Bool_State_Enabled_Should_Return_true_for_Target_three",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "true"
+				}
+			],
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Bool_State_Enabled_Should_Return_true_for_Target_three",
+			"target": "three",
+			"expected": true
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_complexJSON_for_Target_five.json
+++ b/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_complexJSON_for_Target_five.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "validJSON"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_JSON_State_Enabled_Should_Return_complexJSON_for_Target_five",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "complexJSON"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "emptyJSON"
+				}
+			],
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_JSON_State_Enabled_Should_Return_complexJSON_for_Target_five",
+			"target": "five",
+			"expected": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_emptyJSON_for_Target_four.json
+++ b/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_emptyJSON_for_Target_four.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "validJSON"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_JSON_State_Enabled_Should_Return_emptyJSON_for_Target_four",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "complexJSON"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "emptyJSON"
+				}
+			],
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_JSON_State_Enabled_Should_Return_emptyJSON_for_Target_four",
+			"target": "four",
+			"expected": "{}"
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_validJSON_for_Target_anonymous.json
+++ b/tests/TargetRules/TargetRules_Type_JSON_State_Enabled_Should_Return_validJSON_for_Target_anonymous.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "validJSON"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_JSON_State_Enabled_Should_Return_validJSON_for_Target_anonymous",
+			"kind": "json",
+			"offVariation": "emptyJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "complexJSON"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "emptyJSON"
+				}
+			],
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_JSON_State_Enabled_Should_Return_validJSON_for_Target_anonymous",
+			"target": "anonymous",
+			"expected": "{\"number\": \"£5\"}"
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_2_for_Target_four.json
+++ b/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_2_for_Target_four.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "0.11"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Number_State_Enabled_Should_Return_2_for_Target_four",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "324523"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "2"
+				}
+			],
+			"variations": [
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Number_State_Enabled_Should_Return_2_for_Target_four",
+			"target": "four",
+			"expected": 2
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_324523_for_Target_five.json
+++ b/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_324523_for_Target_five.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "0.11"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Number_State_Enabled_Should_Return_324523_for_Target_five",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "324523"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "2"
+				}
+			],
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Number_State_Enabled_Should_Return_324523_for_Target_five",
+			"target": "five",
+			"expected": 324523
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_sonnet53_for_Target_anonymous.json
+++ b/tests/TargetRules/TargetRules_Type_Number_State_Enabled_Should_Return_sonnet53_for_Target_anonymous.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "0.11"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_Number_State_Enabled_Should_Return_sonnet53_for_Target_anonymous",
+			"kind": "int",
+			"offVariation": "2",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "324523"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "2"
+				}
+			],
+			"variations": [
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				},
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_Number_State_Enabled_Should_Return_sonnet53_for_Target_anonymous",
+			"target": "anonymous",
+			"expected": 0.11
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_anonymous.json
+++ b/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_anonymous.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_anonymous",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "thehobbit"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "sonnet53"
+				}
+			],
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_anonymous",
+			"target": "anonymous",
+			"expected": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_four.json
+++ b/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_four.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_four",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "thehobbit"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "sonnet53"
+				}
+			],
+			"variations": [
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_String_State_Enabled_Should_Return_sonnet53_for_Target_four",
+			"target": "four",
+			"expected": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+		}
+	]
+}

--- a/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_thehobbit_for_Target_five.json
+++ b/tests/TargetRules/TargetRules_Type_String_State_Enabled_Should_Return_thehobbit_for_Target_five.json
@@ -1,0 +1,665 @@
+{
+	"flags": [
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_Bool_State_Enabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_str_State_Enabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_int_State_Enabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOn_Type_json_State_Enabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_str_State_Disabled_On_sonnet19_Off_sonnet53_",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				},
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "true"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_Bool_State_Disabled_On_True_Off_False_",
+			"kind": "boolean",
+			"offVariation": "false",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "True",
+					"identifier": "true",
+					"name": "True",
+					"value": "true"
+				},
+				{
+					"description": "False",
+					"identifier": "false",
+					"name": "False",
+					"value": "false"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "2"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_int_State_Disabled_On_2_Off_011_",
+			"kind": "int",
+			"offVariation": "0.11",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "a decimal number",
+					"identifier": "0.11",
+					"name": "Decimal",
+					"value": "0.11"
+				},
+				{
+					"description": "a whole number",
+					"identifier": "2",
+					"name": "Two",
+					"value": "2"
+				},
+				{
+					"description": "a big number",
+					"identifier": "324523",
+					"name": "Small Number",
+					"value": "324523"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "complexJSON"
+			},
+			"environment": "",
+			"feature": "AlwaysOff_Type_json_State_Disabled_On_Com_Off_Val_",
+			"kind": "json",
+			"offVariation": "validJSON",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "off",
+			"variationToTargetMap": null,
+			"variations": [
+				{
+					"description": "A valid piece of JSON",
+					"identifier": "validJSON",
+					"name": "Valid JSON",
+					"value": "{\"number\": \"£5\"}"
+				},
+				{
+					"description": "A Valid empty JSON object",
+					"identifier": "emptyJSON",
+					"name": "Empty JSON",
+					"value": "{}"
+				},
+				{
+					"description": "JSON object containing multiple keys",
+					"identifier": "complexJSON",
+					"name": "Complex JSON",
+					"value": "{\"Beer\": \"£5\", \"Wine\": \"£6.50\"}"
+				}
+			],
+			"version": 1
+		},
+		{
+			"defaultServe": {
+				"variation": "sonnet19"
+			},
+			"environment": "",
+			"feature": "TargetRules_Type_String_State_Enabled_Should_Return_thehobbit_for_Target_five",
+			"kind": "string",
+			"offVariation": "sonnet53",
+			"prerequisites": null,
+			"project": "testproject",
+			"rules": null,
+			"state": "on",
+			"variationToTargetMap": [
+				{
+					"targets": [
+						{
+							"identifier": "one",
+							"name": ""
+						},
+						{
+							"identifier": "three",
+							"name": ""
+						},
+						{
+							"identifier": "five",
+							"name": ""
+						},
+						{
+							"identifier": "seven",
+							"name": ""
+						}
+					],
+					"variation": "thehobbit"
+				},
+				{
+					"targets": [
+						{
+							"identifier": "two",
+							"name": ""
+						},
+						{
+							"identifier": "four",
+							"name": ""
+						},
+						{
+							"identifier": "six",
+							"name": ""
+						},
+						{
+							"identifier": "eight",
+							"name": ""
+						}
+					],
+					"variation": "sonnet53"
+				}
+			],
+			"variations": [
+				{
+					"description": "An excerpt from the hobbit",
+					"identifier": "thehobbit",
+					"name": "The Hobbit",
+					"value": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+				},
+				{
+					"description": "another small sonnet",
+					"identifier": "sonnet19",
+					"name": "Sonnet 19",
+					"value": "Devouring Time, blunt thou the lion’s paws,\nAnd make the earth devour her own sweet brood;\nPluck the keen teeth from the fierce tiger’s jaws,\nAnd burn the long-liv’d phoenix, in her blood;\nMake glad and sorry seasons as thou fleet’st,\nAnd do whate’er thou wilt, swift-footed Time,\nTo the wide world and all her fading sweets;\nBut I forbid thee one most heinous crime:\nO! carve not with thy hours my love’s fair brow,\nNor draw no lines there with thine antique pen;\nHim in thy course untainted do allow\nFor beauty’s pattern to succeeding men.\nYet, do thy worst old Time: despite thy wrong,\nMy love shall in my verse ever live young."
+				},
+				{
+					"description": "a small sonnet",
+					"identifier": "sonnet53",
+					"name": "Sonnet 53",
+					"value": "What is your substance, whereof are you made,\nThat millions of strange shadows on you tend?\nSince every one hath, every one, one shade,\nAnd you but one, can every shadow lend.\nDescribe Adonis, and the counterfeit\nIs poorly imitated after you;\nOn Helen’s cheek all art of beauty set,\nAnd you in Grecian tires are painted new:\nSpeak of the spring, and foison of the year,\nThe one doth shadow of your beauty show,\nThe other as your bounty doth appear;\nAnd you in every blessed shape we know.\nIn all external grace you have some part,\nBut you like none, none you, for constant heart."
+				}
+			],
+			"version": 1
+		}
+	],
+	"segments": [
+		{
+			"excluded": null,
+			"identifier": "IncludedOnly",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "ExcludedOnly",
+			"included": null,
+			"name": "Group that excludes targets"
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "four",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "five",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "six",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "IncludeAndExcludeGroup",
+			"included": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "one",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "two",
+					"name": "",
+					"org": "",
+					"project": ""
+				},
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"name": "Group that includes and excludes targets"
+		},
+		{
+			"excluded": null,
+			"identifier": "StartsWithT",
+			"included": null,
+			"name": "Starts With T",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsOne",
+			"included": null,
+			"name": "Equals With One",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"one"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsTwo",
+			"included": null,
+			"name": "Equals With Two",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"two"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "EqualsThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": [
+				{
+					"account": "",
+					"environment": "",
+					"identifier": "three",
+					"name": "",
+					"org": "",
+					"project": ""
+				}
+			],
+			"identifier": "StartsWithTExcludesThree",
+			"included": null,
+			"name": "Equals With Three",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "starts_with",
+					"values": [
+						"t"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "InOneTwoThree",
+			"included": null,
+			"name": "In operator with multiple values",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "in",
+					"values": [
+						"one",
+						"two",
+						"three"
+					]
+				}
+			]
+		},
+		{
+			"excluded": null,
+			"identifier": "GroupWithMultipleOrRules",
+			"included": null,
+			"name": "Equals With Three and two other rules",
+			"rules": [
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"madeupnotreal"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"three"
+					]
+				},
+				{
+					"attribute": "identifier",
+					"negate": false,
+					"op": "equal",
+					"values": [
+						"anothermadeupvalue"
+					]
+				}
+			]
+		}
+	],
+	"targets": [
+		{
+			"identifier": "one",
+			"name": "Target One",
+			"attributes": {
+				"location": "emea"
+			}
+		},
+		{
+			"identifier": "two",
+			"name": "Target Two",
+			"attributes": null
+		},
+		{
+			"identifier": "three",
+			"name": "Target Three",
+			"attributes": null
+		},
+		{
+			"identifier": "four",
+			"name": "Target Four",
+			"attributes": null
+		},
+		{
+			"identifier": "five",
+			"name": "Target Five",
+			"attributes": null
+		},
+		{
+			"identifier": "six",
+			"name": "Target Six",
+			"attributes": null
+		},
+		{
+			"identifier": "seven",
+			"name": "Target Seven",
+			"attributes": null
+		},
+		{
+			"identifier": "eight",
+			"name": "Target Eight",
+			"attributes": null
+		},
+		{
+			"identifier": "anonymous",
+			"name": "Anonymous Target",
+			"attributes": null
+		}
+	],
+	"tests": [
+		{
+			"flag": "TargetRules_Type_String_State_Enabled_Should_Return_thehobbit_for_Target_five",
+			"target": "five",
+			"expected": "In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the\nends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down\non or to eat: it was a hobbit­hole, and that means comfort.\nIt had a perfectly round door like a porthole, painted green, with a shiny yellow brass knob\nin the exact middle. The door opened on to a tube­shaped hall like a tunnel: a very comfortable\ntunnel without smoke, with panelled walls, and floors tiled and carpeted, provided with polished\nchairs, and lots and lots of pegs for hats and coats ­ the hobbit was fond of visitors. The tunnel\nwound on and on, going fairly but not quite straight into the side of the hill ­ The Hill, as all the\npeople for many miles round called it ­ and many little round doors opened out of it, first on\none side and then on another. No going upstairs for the hobbit: bedrooms, bathrooms, cellars,\npantries (lots of these), wardrobes (he had whole rooms devoted to clothes), kitchens,\ndining­rooms, all were on the same floor, and indeed on the same passage. The best rooms\nwere all on the left­hand side (going in), for these were the only ones to have windows,\ndeep­set round windows looking over his garden and meadows beyond, sloping down to the\nriver."
+		}
+	]
+}

--- a/tests/bool_on_simple_rule.json
+++ b/tests/bool_on_simple_rule.json
@@ -4,7 +4,7 @@
     {
       "defaultServe": { "distribution": null, "variation": "true" },
       "environment": "dev",
-      "feature": "bool-flag",
+      "feature": "bool-flag-on",
       "kind": "boolean",
       "offVariation": "false",
       "prerequisites": [],
@@ -58,8 +58,8 @@
     }
   ],
   "tests": [
-    { "flag": "bool-flag", "expected": true },
-    { "flag": "bool-flag", "target": "harness", "expected": false },
-    { "flag": "bool-flag", "target": "enver", "expected": true }
+    { "flag": "bool-flag-on", "expected": true },
+    { "flag": "bool-flag-on", "target": "harness", "expected": false },
+    { "flag": "bool-flag-on", "target": "enver", "expected": true }
   ]
 }

--- a/tests/off_flag.json
+++ b/tests/off_flag.json
@@ -4,7 +4,7 @@
     {
       "defaultServe": { "distribution": null, "variation": "true" },
       "environment": "dev",
-      "feature": "bool-flag",
+      "feature": "bool-flag-off",
       "kind": "boolean",
       "offVariation": "false",
       "prerequisites": [],
@@ -41,7 +41,7 @@
     }
   ],
   "tests": [
-    { "flag": "bool-flag", "expected": false },
-    { "flag": "bool-flag", "target": "harness", "expected": false }
+    { "flag": "bool-flag-off", "expected": false },
+    { "flag": "bool-flag-off", "target": "harness", "expected": false }
   ]
 }

--- a/tests/off_off_no_rules.json
+++ b/tests/off_off_no_rules.json
@@ -4,7 +4,7 @@
     {
       "defaultServe": { "distribution": null, "variation": "false" },
       "environment": "demoenv",
-      "feature": "bool-flag",
+      "feature": "bool-flag-on-serve-false",
       "kind": "boolean",
       "offVariation": "false",
       "prerequisites": [],
@@ -41,7 +41,7 @@
     }
   ],
   "tests": [
-    { "flag": "bool-flag", "expected": false },
-    { "flag": "bool-flag", "target": "harness", "expected": false }
+    { "flag": "bool-flag-on-serve-false", "expected": false },
+    { "flag": "bool-flag-on-serve-false", "target": "harness", "expected": false }
   ]
 }

--- a/tests/on_off_no_rules.json
+++ b/tests/on_off_no_rules.json
@@ -4,7 +4,7 @@
     {
       "defaultServe": { "distribution": null, "variation": "true" },
       "environment": "dev",
-      "feature": "bool-flag",
+      "feature": "bool-flag-on-serve-true",
       "kind": "boolean",
       "offVariation": "false",
       "prerequisites": [],
@@ -41,7 +41,7 @@
     }
   ],
   "tests": [
-    { "flag": "bool-flag", "expected": true },
-    { "flag": "bool-flag", "target": "harness", "expected": true }
+    { "flag": "bool-flag-on-serve-true", "expected": true },
+    { "flag": "bool-flag-on-serve-true", "target": "harness", "expected": true }
   ]
 }


### PR DESCRIPTION
Checkin the ff-test-grid test cases.  These are the tests defined https://github.com/wings-software/ff-server/tree/master/tests/features and converted to the ff-test-case format using https://github.com/wings-software/ff-server/tree/master/cmd/ff-test-case.

To increase test coverage, and also reduce overhead.  We can focus on writing test-cases for the test grid, but generate test files for use by the SDKs.